### PR TITLE
Fix cookie setting issue

### DIFF
--- a/src/Cartalyst/Sentry/Cookies/IlluminateCookie.php
+++ b/src/Cartalyst/Sentry/Cookies/IlluminateCookie.php
@@ -111,10 +111,8 @@ class IlluminateCookie implements CookieInterface {
 	 */
 	public function forever($value)
 	{
-		//$cookie = $this->jar->forever($this->getKey(), $value);
-		//$this->jar->queue($cookie);
-		// Replace it with a correct encoding method
-        setcookie($this->getKey(), base64_encode(implode('`', $value)));
+	    $cookie = $this->jar->forever($this->getKey(), json_encode($value));
+	    $this->jar->queue($cookie);
 	}
 
 	/**

--- a/src/Cartalyst/Sentry/Sessions/IlluminateSession.php
+++ b/src/Cartalyst/Sentry/Sessions/IlluminateSession.php
@@ -81,14 +81,7 @@ class IlluminateSession implements SessionInterface {
 	 */
 	public function get()
 	{
-		//return $this->session->get($this->getKey());
-		$key = $this->getKey();
-        if (array_key_exists($key, $_COOKIE)) {
-            // Replace it with a correct decoding method
-            return explode('`', base64_decode($_COOKIE[$key]));
-        } else {
-            return null;
-        }
+		return $this->session->get($this->getKey());
 	}
 
 	/**


### PR DESCRIPTION
Argument 2 passed to Symfony\Component\HttpFoundation\Cookie::__construct() must be of the type string or null, array given